### PR TITLE
CI should use a fixed version of numpy to install to reproduce old answers

### DIFF
--- a/.github/workflows/basic_test.yml
+++ b/.github/workflows/basic_test.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.10.2'
     - name: Install pytest
       run: python3 -m pip install pytest
     - name: Install numpypi

--- a/.github/workflows/basic_test.yml
+++ b/.github/workflows/basic_test.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '>=3.6'
+        python-version: '3.8'
     - name: Install pytest
       run: python3 -m pip install pytest
     - name: Install numpypi

--- a/.github/workflows/basic_test.yml
+++ b/.github/workflows/basic_test.yml
@@ -12,6 +12,8 @@ jobs:
         python-version: '3.10.2'
     - name: Install pytest
       run: python3 -m pip install pytest
+    - name: Install numpy
+      run: python3 -m pip install numpy==1.22.2
     - name: Install numpypi
       run: python3 -m pip install git+https://github.com/adcroft/numpypi.git
     - name: Install netCDF4 dependencies


### PR DESCRIPTION
It looks like the new version of numpy that CI installs (1.22.3) is causing answers (grid checksum values) to change compared to the older version of numpy (1.22.2) that these answers were recorded with. 
To avoid these checks from failing we can direct github CI to install the specific versions of python and numpy .
With these versions the checksums are the same in github platform , PAN and workstations (which use numpy 1.20.1).