### PR TITLE
Swap numpy.round_() with numpy.round()

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ Required python packages:
 - numpypi : python -m pip install git+https://github.com/underwoo/numpypi@pip.installable
  
 To test this module quickly try
-- cd extras ; make -f Makefile.examples quick
+- cd extras ; make quick
 
 Examples:
 - To build a grid consisting a 1/2 degree regular spherical grid between 50S and 70S, stitched with  a displaced pole cap south of 70S with the south pole displaced to (60E,50S):
  
   ocean_grid_generator.py -r 2  --south_ocean_upper_lat -50 --south_cap_lat -70 --lon_dp 60.0 --lat_dp -85.85 --grids so sc [--skip_metrics --plot] 
+
 
 [Technical guide](https://github.com/nikizadehgfdl/grid_generation/blob/dev/ocean_grid_generator_guide.pdf)
 

--- a/extras/Makefile
+++ b/extras/Makefile
@@ -5,8 +5,8 @@ TARGS = ocean_hgrid_res4.0.nc \
         ocean_hgrid_res0.5.nc \
         ocean_hgrid_res0.5_equenh.nc \
         ocean_hgrid_res0.25.nc \
-	ocean_hgrid_res0.25_om5proto.nc \
-        ocean_hgrid_res0.125.nc 
+	ocean_hgrid_res0.25_om5proto.nc
+        #ocean_hgrid_res0.125.nc 
 
 #Note: Github Travis cannot make the higher res grids below and errors out with "MemoryError"
 #      That is why they are commented out from TARGS so Travis can finish to keep records.   
@@ -37,11 +37,15 @@ ocean_hgrid_res0.25.nc:
 	time $(TOOL) $(DEBUG) -f ocean_hgrid_res0.25.nc -r 4 --r_dp 0.2 --south_cutoff_row 83 --write_subgrid_files --no_changing_meta
 ocean_hgrid_res0.25_om5proto.nc:
 	time $(TOOL) $(DEBUG) -f ocean_hgrid_res0.25_om5proto.nc -r 4 --south_ocean_lower_lat -88.57 --match_dy so  --no_south_cap --write_subgrid_files --no_changing_meta
-ocean_hgrid_res0.125.nc:
-	time $(TOOL) $(DEBUG) -f ocean_hgrid_res0.125.nc -r 8 --r_dp 0.2 --south_cutoff_row 5 --match_dy bp so p125sc --ensure_nj_even --write_subgrid_files --no_changing_meta
+#ocean_hgrid_res0.125.nc:
+#	time $(TOOL) $(DEBUG) -f ocean_hgrid_res0.125.nc -r 8 --r_dp 0.2 --south_cutoff_row 5 --match_dy bp so p125sc --ensure_nj_even --write_subgrid_files --no_changing_meta
 
 
 hash.md5.gfdl-pan105: | $(TARGS)
+	md5sum $(TARGS) > $@
+	cat $@
+
+hash.md5: 
 	md5sum $(TARGS) > $@
 	cat $@
 

--- a/extras/hash.md5
+++ b/extras/hash.md5
@@ -1,1 +1,1 @@
-hash.md5.gfdl-pan105
+hash.md5.gfdl-ws

--- a/extras/hash.md5.gfdl-pan105
+++ b/extras/hash.md5.gfdl-pan105
@@ -2,6 +2,5 @@
 4d4f9647dc8b354488c725a9e6ed8d09  ocean_hgrid_res1.0.nc
 af81a52a2d538bcbf1ac937b488bcdc9  ocean_hgrid_res0.5.nc
 64399b4e6c0a82183ece4c07d4fc48c8  ocean_hgrid_res0.5_equenh.nc
-f25df1790ec0af672036d58c68125c69  ocean_hgrid_res0.25.nc
+34975abd9dafd4b61b1de3c05ab838d1  ocean_hgrid_res0.25.nc
 28c576a0d0314c4ef107dce4d10dfa89  ocean_hgrid_res0.25_om5proto.nc
-b382087f5259eaad3fb9a0019eccce43  ocean_hgrid_res0.125.nc

--- a/extras/hash.md5.gfdl-ws
+++ b/extras/hash.md5.gfdl-ws
@@ -1,7 +1,6 @@
-#works for gfdl-ws, pan106 
-0ecf1226cda789e225bfa65edadc509c  ocean_hgrid_res4.0.nc
-f49fd3bdbfe4c4764802c591341b1ea2  ocean_hgrid_res1.0.nc
-01d0bfa698d16cec35320c5eaea58a48  ocean_hgrid_res0.5.nc
-cdbe7784f00a0ca8139da4019a961f89  ocean_hgrid_res0.5_equenh.nc
-e105c3f0ca219299015065178c18b998  ocean_hgrid_res0.25.nc
-b382087f5259eaad3fb9a0019eccce43  ocean_hgrid_res0.125.nc
+ae4edcf1e642e8814f6d251b794502ab  ocean_hgrid_res4.0.nc
+0e0e0516de806e3e7eafe843c91cd0b6  ocean_hgrid_res1.0.nc
+40ec628816f345f7f32bd083b1daed7a  ocean_hgrid_res0.5.nc
+e05ad585e54bced814792957f2aa64c8  ocean_hgrid_res0.5_equenh.nc
+5982d645b30fda55851ab702ed154cbb  ocean_hgrid_res0.25.nc
+ade918163ce229ab4bcec67950f58421  ocean_hgrid_res0.25_om5proto.nc

--- a/extras/reproducibility_notes
+++ b/extras/reproducibility_notes
@@ -1,33 +1,12 @@
-10/29/2021
+07/31/2024
 ----------
 The md5 checksum hashes were obtained by using the following python setup
 
-export PYTHONPATH="/net2/nnz/opt/miniconda/lib/python3.8/site-packages"; export PATH="/net2/nnz/opt/miniconda/bin:$PATH"; export HDF5_USE_FILE_LOCKING=FALSE ; . activate om4labs
+export PATH="/net2/nnz/opt/miniconda/bin:$PATH"; export HDF5_USE_FILE_LOCKING=FALSE ; . activate platforms
 
-Currenly the checksum don't match between gfdl-ws and gfdl-pan for 1/4 and 1/8 degree grids (ocean_hgrid_res0.25.nc and ocean_hgrid_res0.125.nc )
+The tests were run on gfdl-ws , gfdl-pan-* using the same python executable and environment as shown above!
 
-#################################################
-OLD, deprecated
-#################################################
-#On gfdl pan the following were checked identical
+There seems  to be at least two sets of different answers for two sets of platforms:
+- Checksums match between gfdl-ws , gfdl-pan-202 , awscloud, 
+- Checksums match between gfdl-pan-10* , gfdl amdbox 
 
-#To reproduce MIDAS grids:
-#OM4p25
-module load python/2.7.3_workstation
-/work/Niki.Zadeh/grid_generation/ocean_grid_generator.py -f ocean_hgrid_res0.25_MIDAS.nc -r 4 --south_cutoff_row 81 --reproduce_MIDAS_grids --write_subgrid_files
-nccmp -d ocean_hgrid_res0.25_MIDAS.nc  /archive/gold/datasets/OM4_025/mosaic.v20170622.unpacked/ocean_hgrid.nc
-
-#OM4p5
-module swap python/2.7.3_workstation
-/work/Niki.Zadeh/grid_generation/ocean_grid_generator.py -f ocean_hgrid_res0.5_MIDAS.nc -r 2 --rdp 0 --south_cutoff_row 81 --reproduce_MIDAS_grids --write_subgrid_files
-nccmp -d ocean_hgrid_res0.5_MIDAS.nc  /archive/gold/datasets/OM4_05/mosaic_ocean.v20180227.unpacked/ocean_hgrid.nc    
-
-#To reproduce 1/8 degree JRA grid
-module swap python/3.6.4    #Note the version
-/work/Niki.Zadeh/grid_generation/ocean_grid_generator.py -f ocean_hgrid_res0.125_old.nc -r 8 --write_subgrid_files --reproduce_old8_grids --write_subgrid_files
-nccmp -d ocean_hgrid_res0.125_old.nc /archive/Niki.Zadeh/input/xanadu/OM4p125_grid/unpacked/ocean_hgrid.nc
-
-#On gfdl workstation I get
-#nccmp -d ocean_hgrid_res0.125_old.nc  /archive/Niki.Zadeh/input/xanadu/OM4p125_grid/unpacked/ocean_hgrid.nc
-#DIFFER : VARIABLE : y : POSITION : 1 1362 : VALUES : -83.4759 <> -83.4759
-#This means something has changed in my python envoirons since I produced that grid in July2018

--- a/ocean_grid_generator.py
+++ b/ocean_grid_generator.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 import numpypi.numpypi_series as np
 
-# import numpy as np
+import numpy
 import argparse
 import sys, getopt
 import datetime, os, subprocess
@@ -308,7 +308,7 @@ def d_phi_mercator_dy(Ni, y):
 
 def y_mercator_rounded(Ni, phi):
     y_float = y_mercator(Ni, phi)
-    return (np.sign(y_float) * np.round_(np.abs(y_float))).astype(int)
+    return (np.sign(y_float) * numpy.round(np.abs(y_float))).astype(int)
 
 
 def generate_mercator_grid(Ni, phi_s, phi_n, lon0_M, lenlon_M, refineR,


### PR DESCRIPTION
- swap numpy.round_() with numpy.round(), no answer change
- numpy.round_() function is removed from numpy starting at version 2.0.0
- This causes github Action tests to fail